### PR TITLE
Sync and deprecate wbnns fork

### DIFF
--- a/_posts/2020-02-03-coinshuffle++.md
+++ b/_posts/2020-02-03-coinshuffle++.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title:  "CoinShuffle++"
+date:   2020-02-03 20:00 -0000
+---
+
+### Time: 20:00 UTC
+### Location: [Hangouts](https://hangouts.google.com/call/CQ1iuILE1j2js95DzgrzAEEE)
+
+## Resources
+
++ [CoinShuffle++](https://www.ndss-symposium.org/wp-content/uploads/2017/09/ndss201701-4RuffingPaper.pdf)

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@ title: Home
     <li>Anyone is free to join the discussions, however, being familiar with the topic is recommended.</li>
     <li>5-15 minutes presentations on the topic are welcomed.</li>
   </ul>
-  <h3>Upcoming / Most Recent</h3>
+  <h2>Meetings</h2>
   <ul class="post-list">
-    {% for post in site.posts limit:1 %}
+    {% for post in site.posts %}
       <li>
         <span class="post-meta">{{ post.date | date: "%b
             %-d, %Y" }} @ {{ post.date | date: "%H:%M" }} UTC</span>
@@ -21,15 +21,3 @@ title: Home
     {% endfor %}
   </ul>
 </div>
-
-<h3>Past</h3>
-
-<ul class="post-list">
-  {% for post in site.posts offset:1 %}
-    <li>
-      <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }} @ {{
-          post.date | date: "%H:%M" }} UTC</span>
-      <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-    </li>
-  {% endfor %}
-</ul>


### PR DESCRIPTION
I've set up CI on the main repository for the club (`zkSNACKs/WasabiResearchClub`). This PR adds the upcoming topic, `CoinShuffle++` to the main repository so that it correctly appears on the website and is fully in sync with the fork (it was previously only added to the fork).

The fork will be deleted once this is merged.