### PR TITLE
aftershowtodo: Fix broken link

### DIFF
--- a/AfterShowToDo.md
+++ b/AfterShowToDo.md
@@ -1,6 +1,6 @@
 - [ ] Upload recording to YouTube
 - [ ] Update README.md with next session (Example: https://github.com/zkSNACKs/WasabiResearchClub/commit/c3903548c0b5f635229fc9c92c39f2b38bbb02a3)
-- [ ] Update the website with next session (Example: https://github.com/wbnns/WasabiResearchClub/commit/436f2d46d16efd1fb2a01b290c1007fd5d47512f)
+- [ ] Update the website with next session by adding a new file in `_posts/` (Example: https://github.com/zkSNACKs/WasabiResearchClub/commit/a81323e69b2e57eaa5ea4a2ea22e0bd941beefb5#commitcomment-36995271)
 - [ ] Send out emails to the authors of the next paper.
 - [ ] Tweet
 - [ ] Submit to Reddit


### PR DESCRIPTION
This fixes a broken link in `AfterShowToDo.md` as a result of me
deleting my fork of the main repository.