### PR TITLE
git: Add '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+_site/
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+.bundle
+vendor
+_cache
+.jekyll-metadata
+.sass-cache/


### PR DESCRIPTION
This adds a `.gitignore` to the repository so that unneeded files from
local environments and Jekyll builds (Jekyll is what serves the website)
don't get committed to the main repository.